### PR TITLE
refactor sys_get_time

### DIFF
--- a/os8/src/syscall/process.rs
+++ b/os8/src/syscall/process.rs
@@ -120,17 +120,17 @@ pub fn sys_waitpid(pid: isize, exit_code_ptr: *mut i32) -> isize {
     // ---- release current PCB lock automatically
 }
 
-pub fn sys_get_time(_ts: *mut TimeVal, _tz: usize) -> isize {
-    let _us = get_time_us();
+pub fn sys_get_time(ts: *mut TimeVal, _tz: usize) -> isize {
+    let us = get_time_us();
     // unsafe {
     //     *ts = TimeVal {
     //         sec: us / 1_000_000,
     //         usec: us % 1_000_000,
     //     };
     // }
-    *translated_refmut(current_user_token(), _ts) = TimeVal {
-        sec: _us / 1_000_000,
-        usec: _us % 1_000_000,
+    *translated_refmut(current_user_token(), ts) = TimeVal {
+        sec: us / 1_000_000,
+        usec: us % 1_000_000,
     };
     0
 }


### PR DESCRIPTION
565d6cd: the variable is used. remove the underscore